### PR TITLE
documentation(839873): Add the correct path.

### DIFF
--- a/ej2-javascript/dialog/index.md
+++ b/ej2-javascript/dialog/index.md
@@ -26,9 +26,9 @@ There are two types of Dialog:
 * **[Templates](./template)**: - Customizable Dialog header and footer through the
 template.
 
-* **[Draggable](../../getting-started#draggable)**: - Supports to drag the Dialog within the page or container.
+* **[Draggable](../../getting-started/#draggable)**: - Supports to drag the Dialog within the page or container.
 
-* **[Positioning](../../getting-started#positioning)**: - Provided support to
+* **[Positioning](../../getting-started/#positioning)**: - Provided support to
 position on built-in 9 places or any custom location.
 
 * **[Animation](./animation)**: - Provided built-in animation support on open & close the Dialog with customization.
@@ -37,4 +37,4 @@ position on built-in 9 places or any custom location.
 
 * **[Accessibility](./accessibility)**: - Built-in compliance with the [WAI-ARIA](http://www.w3.org/WAI/PF/aria-practices/) specifications.
 
-* **[Keyboard Interaction](./accessibility#keyboard-interaction)**: - The Dialog can be intractable through keyboard.
+* **[Keyboard Interaction](./accessibility/#keyboard-interaction)**: - The Dialog can be intractable through keyboard.

--- a/ej2-javascript/predefined-dialogs/customization.md
+++ b/ej2-javascript/predefined-dialogs/customization.md
@@ -117,7 +117,7 @@ When rendering the predefined dialogs through utility methods, You can close the
 * By pressing the escape key if the [closeOnEscape](https://ej2.syncfusion.com/documentation/api/dialog/#closeonescape) property is enabled.
 * By clicking the close button if the [showCloseIcon](https://ej2.syncfusion.com/documentation/api/dialog/#showcloseicon) property is enabled.
 
-You can also manually close the Dialogs by creating an instance to the dialog and call the [hide](https://ej2.syncfusion.com/angular/documentation/api/dialog#hide) method.
+You can also manually close the Dialogs by creating an instance to the dialog and call the [hide](https://ej2.syncfusion.com/angular/documentation/api/dialog/#hide) method.
 
 Use the following code for **alert**, **confirm** and **prompt** to demonstrates the different ways of hiding the utility dialog.
 

--- a/ej2-javascript/tooltip/how-to/custom-tooltip-with-dynamic-html.md
+++ b/ej2-javascript/tooltip/how-to/custom-tooltip-with-dynamic-html.md
@@ -11,7 +11,7 @@ domainurl: ##DomainURL##
 
 # Custom tooltip with dynamic html in ##Platform_Name## Tooltip control
 
-Tooltip loads HTML pages via HTML tags such as iframe, video, and map using the [`content`](../../api/tooltip#content) property, which supports both string and HTML tags.
+Tooltip loads HTML pages via HTML tags such as iframe, video, and map using the [`content`](../../api/tooltip/#content) property, which supports both string and HTML tags.
 
 To load an `iframe` element in tooltip, set the required iframe in the `content` of tooltip while initializing the tooltip component. Refer to the following code.
 

--- a/ej2-javascript/tooltip/how-to/dynamic-tooltip-content-with-html.md
+++ b/ej2-javascript/tooltip/how-to/dynamic-tooltip-content-with-html.md
@@ -17,7 +17,7 @@ The HTML tags such as `<div>`, `<span>`, `bold`, `italic`, `underline`, etc., ca
 
 Here, Bold, Italic, Underline, and Anchor tags are used.
 
-When using HTML elements as content to `Tooltip` make the content element `display: none`, then from the [`beforeRender`](../../api/tooltip#beforerender) event we can make the element visible again using below code.
+When using HTML elements as content to `Tooltip` make the content element `display: none`, then from the [`beforeRender`](../../api/tooltip/#beforerender) event we can make the element visible again using below code.
 
 ```ts
     document.getElementById('content').style.display = 'block';

--- a/ej2-javascript/tooltip/how-to/dynamic-tooltip-content.md
+++ b/ej2-javascript/tooltip/how-to/dynamic-tooltip-content.md
@@ -13,7 +13,7 @@ domainurl: ##DomainURL##
 
 The tooltip content can be changed dynamically using the [AJAX](../../api/base/ajax/) request.
 
-The AJAX request should be made within the [`beforeRender`](../../api/tooltip#beforerender) event of the tooltip. On every success, the corresponding retrieved data will be set to the [content](../../api/tooltip#content) property of the tooltip.
+The AJAX request should be made within the [`beforeRender`](../../api/tooltip/#beforerender) event of the tooltip. On every success, the corresponding retrieved data will be set to the [content](../../api/tooltip/#content) property of the tooltip.
 
 When you hover over the icons, its respective data will be retrieved dynamically and then assigned to the tooltip’s content.
 

--- a/ej2-javascript/tooltip/how-to/fancy-tooltip-customization.md
+++ b/ej2-javascript/tooltip/how-to/fancy-tooltip-customization.md
@@ -73,7 +73,7 @@ bubble.appendTo('#bubbletip');
 
 These tip arrow customizations have been achieved through CSS changes in the sample level. The tooltip position can be changed by using the radio button click event.
 
-The arrow tip pointer can also be disabled by using the [`showTipPointer`](../../api/tooltip#showtippointer) property in a tooltip.
+The arrow tip pointer can also be disabled by using the [`showTipPointer`](../../api/tooltip/#showtippointer) property in a tooltip.
 
 {% if page.publishingplatform == "typescript" %}
 


### PR DESCRIPTION
### Redirect description
Need to resolve the Page With Redirect - EJ2 docs links for popups documentation
 
### Solution description
Resolved the Page With Redirect - EJ2 docs links for popups documentation by adding the correct links
 
### Output screenshots
NA
 
### Areas affected and ensured
No area is affected due to this changes.
 
### Test cases
NA
 
### Test bed sample location
NA
 
### Additional checklist
 
* Did you run the automation against your implementation? NA
* Is there any API name change? No
* Is there any existing behavior change of other features due to this code change? No
* Does your new code introduce new warnings or binding errors? No
* Does your code pass all FxCop and StyleCop rules? Yes
* Did you record this case in the unit test or UI test? NA

